### PR TITLE
Fix buffers-tabline error when opening directories

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -391,7 +391,7 @@ function! lightline#tabline()
 endfunction
 
 function! s:tabline(range, active, onefn)
-    let l:range = ( a:range == [] ? [0] : a:range )
+  let l:range = ( a:range == [] ? [0] : a:range )
   let [l, x, y, z, u, d] = [l:range[-1], [], [], [], '...', min([max([winwidth(0) / 40, 2]), 8])]
   for i in l:range
     call add(i<a:active?(x):i==a:active?(y):z, '%'.i.'T%{lightline#one'.a:onefn.'('.i.','.(i==a:active).')}'.(i==l?'%T':''))

--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -391,8 +391,9 @@ function! lightline#tabline()
 endfunction
 
 function! s:tabline(range, active, onefn)
-  let [l, x, y, z, u, d] = [a:range[-1], [], [], [], '...', min([max([winwidth(0) / 40, 2]), 8])]
-  for i in a:range
+    let l:range = ( a:range == [] ? [0] : a:range )
+  let [l, x, y, z, u, d] = [l:range[-1], [], [], [], '...', min([max([winwidth(0) / 40, 2]), 8])]
+  for i in l:range
     call add(i<a:active?(x):i==a:active?(y):z, '%'.i.'T%{lightline#one'.a:onefn.'('.i.','.(i==a:active).')}'.(i==l?'%T':''))
   endfor
   let [a, b, c] = [len(x), len(z), d * 2]


### PR DESCRIPTION
This patch fixes an index out of range exception when opening vim with a
directory as a parameter. The issue is caused because there are no
buffers active when the plugin creates the tabline. Populating the
buffer list with one buffer solves the issue the buffer gets created
before the user gets shown the screen I assume.

The errors this fixes are the following, when calling lightline#tabline
with 'buffers' as a member and opening vim with `vim .`

```
E684: list index out of range: -1
E15: Invalid expression: [a:range[-1], [], [], [], '...', min([max([winwidth(0) / 40, 2]), 8])]
```
